### PR TITLE
Add funding using tokens

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
                 "debug"
             ],
             "env": {
-                "WEBHOOK_SECRET": "fa7689e3"
+                "WEBHOOK_SECRET": ""
             },
             "port": 9229
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug via NPM",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run-script",
+                "debug"
+            ],
+            "env": {
+                "WEBHOOK_SECRET": "fa7689e3"
+            },
+            "port": 9229
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/index.js"
+        }
+    ]
+}

--- a/config/default.js
+++ b/config/default.js
@@ -7,6 +7,42 @@ const BOUNTY_LABELS = {
     'bounty-xl': 10000
 }
 
+const ERC20_ABI = [
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "name": "_to",
+                "type": "address"
+            },
+            {
+                "name": "_amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "transfer",
+        "outputs": [
+            {
+                "name": "success",
+                "type": "bool"
+            }
+        ],
+        "payable": false,
+        "type": "function"
+    }
+];
+
+const TOKEN_CONTRACTS = {
+    'STT': {
+        address: '0xc55cF4B03948D7EBc8b9E8BAD92643703811d162',
+        abi: ERC20_ABI
+    },
+    'SNT': {
+        address: '0x744d70fdbe2ba4cf95131626614a1763df805b9e',
+        abi: ERC20_ABI
+    }
+}
+
 module.exports = {
     // Debug mode for testing the bot
     debug: true,
@@ -37,6 +73,9 @@ module.exports = {
 
     // Bounty Labels for the issues and the correspondent hours (e.g. {'bounty-xs': 3})
     bountyLabels: BOUNTY_LABELS,
+
+    // Contract info for the different supported tokens
+    tokenContracts: TOKEN_CONTRACTS,
 
     // username for the bot which has to comment for starting the process (e.g. status-bounty-)
     githubUsername: 'status-open-bounty',

--- a/index.js
+++ b/index.js
@@ -96,17 +96,17 @@ const processRequest = function (req) {
     return new Promise((resolve, reject) => {
         Promise.all([amountPromise, gasPricePromise])
             .then(function (results) {
-                let amount = results[0];
-                let gasPrice = results[1];
+                const amount = results[0];
+                const gasPrice = results[1];
 
                 bot.sendTransaction(to, amount, gasPrice)
-                    .then(function () {
+                    .then(function (hash) {
+                        bot.logTransaction(hash);
                         resolve();
                     })
                     .catch(function (err) {
                         reject(err);
                     });
-
             })
             .catch(function (err) {
                 reject(err);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
+    "debug": "node --inspect-brk index.js",
     "test": "./node_modules/mocha/bin/mocha"
   },
   "author": "",


### PR DESCRIPTION
This PR:
- allows using different tokens as a funding source, in addition to the existing ETH funding.
- fixes bounty size label interpretation.
- adds configuration for local debugging using VS Code (local endpoint can be exposed to GitHub by running `ngrok http 8181`).