### PR TITLE
Migrate to ES6 syntax and fix console logging

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "standard"
+}

--- a/bot/github.js
+++ b/bot/github.js
@@ -1,52 +1,52 @@
 'use strict'
 
-const https = require('https');
-const config = require('../config');
+const https = require('https')
+const config = require('../config')
 
 // Returns the url for getting the labels of a request (Github API v3)
 // req has req.issue.labels_url
 const getLabelsURL = function (req) {
-    let url = req.body.issue.labels_url;
+    let url = req.body.issue.labels_url
     // Make the URL generic removing the name of the label
-    return url.replace('{/name}', '');
+    return url.replace('{/name}', '')
 }
 
 // Returns  the bounty labelNames of the request, only for testing motives
 const getLabelsMock = function (req) {
-    return new Promise((resolve, reject) => { resolve(req.body.issue.labels) });
+    return new Promise((resolve, reject) => { resolve(req.body.issue.labels) })
 }
 
 // Returns all the bounty labelNames of a given issue (Github API v3)
 const getLabels = function (req) {
     if (config.debug) {
-        return getLabelsMock(req);
+        return getLabelsMock(req)
     } else {
-        const path = getLabelsURL(req).replace('https://api.github.com', '');
+        const path = getLabelsURL(req).replace('https://api.github.com', '')
         const options = {
             hostname: 'api.github.com',
             path: path,
             headers: { 'User-Agent': config.githubUsername }
-        };
+        }
         return new Promise((resolve, reject) => {
             const request = https.get(options, (response) => {
                 // handle http errors
                 if (response.statusCode < 200 || response.statusCode > 299) {
-                    bot.error(response, 'Failed to load page, status code: ' + response.statusCode);
-                    reject(new Error('Failed to load page, status code: ' + response.statusCode));
+                    bot.error(response, 'Failed to load page, status code: ' + response.statusCode)
+                    reject(new Error('Failed to load page, status code: ' + response.statusCode))
                 }
                 // temporary data holder
-                const body = [];
+                const body = []
                 // on every content chunk, push it to the data array
-                response.on('data', (chunk) => body.push(chunk));
+                response.on('data', (chunk) => body.push(chunk))
                 // we are done, resolve promise with those joined chunks
                 response.on('end', () => {
-                    const labels = JSON.parse(body.join('')).map(labelObj => labelObj.name);
-                    resolve(labels);
-                });
-            });
+                    const labels = JSON.parse(body.join('')).map(labelObj => labelObj.name)
+                    resolve(labels)
+                })
+            })
             // handle connection errors of the request
             request.on('error', (err) => reject(err))
-        });
+        })
     }
 }
 

--- a/bot/github.js
+++ b/bot/github.js
@@ -2,54 +2,46 @@
 
 const https = require('https')
 const config = require('../config')
+const bot = require('../bot')
 
 // Returns the url for getting the labels of a request (Github API v3)
 // req has req.issue.labels_url
-const getLabelsURL = function (req) {
-    let url = req.body.issue.labels_url
-    // Make the URL generic removing the name of the label
-    return url.replace('{/name}', '')
-}
-
-// Returns  the bounty labelNames of the request, only for testing motives
-const getLabelsMock = function (req) {
-    return new Promise((resolve, reject) => { resolve(req.body.issue.labels) })
+function getLabelsURL (req) {
+  let url = req.body.issue.labels_url
+  // Make the URL generic removing the name of the label
+  return url.replace('{/name}', '')
 }
 
 // Returns all the bounty labelNames of a given issue (Github API v3)
-const getLabels = function (req) {
-    if (config.debug) {
-        return getLabelsMock(req)
-    } else {
-        const path = getLabelsURL(req).replace('https://api.github.com', '')
-        const options = {
-            hostname: 'api.github.com',
-            path: path,
-            headers: { 'User-Agent': config.githubUsername }
-        }
-        return new Promise((resolve, reject) => {
-            const request = https.get(options, (response) => {
-                // handle http errors
-                if (response.statusCode < 200 || response.statusCode > 299) {
-                    bot.error(response, 'Failed to load page, status code: ' + response.statusCode)
-                    reject(new Error('Failed to load page, status code: ' + response.statusCode))
-                }
-                // temporary data holder
-                const body = []
-                // on every content chunk, push it to the data array
-                response.on('data', (chunk) => body.push(chunk))
-                // we are done, resolve promise with those joined chunks
-                response.on('end', () => {
-                    const labels = JSON.parse(body.join('')).map(labelObj => labelObj.name)
-                    resolve(labels)
-                })
-            })
-            // handle connection errors of the request
-            request.on('error', (err) => reject(err))
-        })
-    }
+function getLabels (req) {
+  const path = getLabelsURL(req).replace('https://api.github.com', '')
+  const options = {
+    hostname: 'api.github.com',
+    path: path,
+    headers: { 'User-Agent': config.githubUsername }
+  }
+  return new Promise((resolve, reject) => {
+    const request = https.get(options, (response) => {
+      // handle http errors
+      if (response.statusCode < 200 || response.statusCode > 299) {
+        bot.error(response, `Failed to load page, status code: ${response.statusCode}`)
+        reject(new Error(`Failed to load page, status code: ${response.statusCode}`))
+      }
+      // temporary data holder
+      const body = []
+      // on every content chunk, push it to the data array
+      response.on('data', (chunk) => body.push(chunk))
+      // we are done, resolve promise with those joined chunks
+      response.on('end', () => {
+        const labels = JSON.parse(body.join('')).map(labelObj => labelObj.name)
+        resolve(labels)
+      })
+    })
+    // handle connection errors of the request
+    request.on('error', (err) => reject(err))
+  })
 }
 
 module.exports = {
-    getLabels: getLabels
+  getLabels: getLabels
 }

--- a/bot/github.js
+++ b/bot/github.js
@@ -7,9 +7,8 @@ const bot = require('../bot')
 // Returns the url for getting the labels of a request (Github API v3)
 // req has req.issue.labels_url
 function getLabelsURL (req) {
-  let url = req.body.issue.labels_url
   // Make the URL generic removing the name of the label
-  return url.replace('{/name}', '')
+  return req.body.issue.labels_url.replace('{/name}', '')
 }
 
 // Returns all the bounty labelNames of a given issue (Github API v3)

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,16 +1,16 @@
-const winston = require('winston');
+const winston = require('winston')
 
-const ethers = require('ethers');
-const Wallet = ethers.Wallet;
-const Contract = ethers.Contract;
-const providers = ethers.providers;
-const utils = ethers.utils;
+const ethers = require('ethers')
+const Wallet = ethers.Wallet
+const Contract = ethers.Contract
+const providers = ethers.providers
+const utils = ethers.utils
 
-const prices = require('./prices');
-const config = require('../config');
-const github = require('./github');
+const prices = require('./prices')
+const config = require('../config')
+const github = require('./github')
 
-const contractAddressString = 'Contract address:';
+const contractAddressString = 'Contract address:'
 
 
 const logger = winston.createLogger({
@@ -21,7 +21,7 @@ const logger = winston.createLogger({
         new winston.transports.File({ filename: './log/info.log', level: 'info' }),
         // new winston.transports.File({ filename: './log/combined.log' })
     ]
-});
+})
 
 
 const needsFunding = function (req) {
@@ -30,22 +30,22 @@ const needsFunding = function (req) {
     } else if (req.body.comment.user.login !== config.githubUsername) {
         return false
     } else if (!hasAddress(req)) {
-        return false;
+        return false
     }
     return true
 }
 
 const hasAddress = function (req) {
-    const commentBody = req.body.comment.body;
+    const commentBody = req.body.comment.body
     if (commentBody.search(contractAddressString) === -1) {
-        return false;
+        return false
     } else {
-        return true;
+        return true
     }
 }
 
 const getAddress = function (req) {
-    const commentBody = req.body.comment.body;
+    const commentBody = req.body.comment.body
     const index = commentBody.search(contractAddressString) + 19
     return commentBody.substring(index, index + 42)
 }
@@ -54,76 +54,76 @@ const getLabel = function (req) {
     return new Promise((resolve, reject) => {
         github.getLabels(req)
             .then(labels => {
-                const bountyLabels = labels.filter(label => config.bountyLabels.hasOwnProperty(label.name));
+                const bountyLabels = labels.filter(label => config.bountyLabels.hasOwnProperty(label.name))
                 if (bountyLabels.length === 1) {
-                    resolve(bountyLabels[0]);
+                    resolve(bountyLabels[0])
                 } else {
-                    reject('Error getting bounty labels');
+                    reject('Error getting bounty labels')
                 }
             }).catch(err => {
-                reject(err);
-            });
-    });
+                reject(err)
+            })
+    })
 }
 
 const getAmountMock = function (req) {
     return new Promise((resolve, reject) => {
-        resolve(10);
-    });
+        resolve(10)
+    })
 }
 
 const getAmount = function (req) {
     return new Promise((resolve, reject) => {
-        const labelPromise = getLabel(req);
-        const tokenPricePromise = prices.getTokenPrice(config.token);
+        const labelPromise = getLabel(req)
+        const tokenPricePromise = prices.getTokenPrice(config.token)
 
         Promise.all([labelPromise, tokenPricePromise])
             .then(function (values) {
-                let label = values[0];
-                let tokenPrice = values[1];
-                let amountToPayDollar = config.priceHour * config.bountyLabels[label.name];
-                resolve(amountToPayDollar / tokenPrice);
+                let label = values[0]
+                let tokenPrice = values[1]
+                let amountToPayDollar = config.priceHour * config.bountyLabels[label.name]
+                resolve(amountToPayDollar / tokenPrice)
             })
             .catch((err) => {
-                reject(err);
-            });
-    });
+                reject(err)
+            })
+    })
 }
 
 
 // Logging functions
 
 const logTransaction = function (tx) {
-    logger.info("[OK] Succesfully funded bounty with transaction " + tx.hash);
-    logger.info(" * From: " + tx.from);
-    logger.info(" * To: " + tx.to);
-    logger.info(" * Amount: " + tx.value);
-    logger.info(" * Gas Price: " + tx.gasPrice);
-    logger.info("====================================================");
+    logger.info("[OK] Succesfully funded bounty with transaction " + tx.hash)
+    logger.info(" * From: " + tx.from)
+    logger.info(" * To: " + tx.to)
+    logger.info(" * Amount: " + tx.value)
+    logger.info(" * Gas Price: " + tx.gasPrice)
+    logger.info("====================================================")
 }
 
 const info = function (msg) {
-    logger.info(msg);
+    logger.info(msg)
 }
 
 const error = function (errorMessage) {
-    logger.error("[ERROR] Request processing failed: " + errorMessage);
+    logger.error("[ERROR] Request processing failed: " + errorMessage)
 }
 
 
 const sendTransaction = async function (to, amount, gasPrice) {
-    var chainId = providers.Provider.chainId.ropsten;
-    var chainName = providers.networks.ropsten;
+    var chainId = providers.Provider.chainId.ropsten
+    var chainName = providers.networks.ropsten
 
     if (config.realTransaction) {
-        chainId = providers.Provider.chainId.homestead;
-        chainName = providers.networks.homestead;
+        chainId = providers.Provider.chainId.homestead
+        chainName = providers.networks.homestead
     }
 
-    const wallet = new Wallet(config.privateKey);
-    const provider = ethers.providers.getDefaultProvider(chainName);
+    const wallet = new Wallet(config.privateKey)
+    const provider = ethers.providers.getDefaultProvider(chainName)
 
-    wallet.provider = provider;
+    wallet.provider = provider
     if (config.token === 'ETH') {
         const transaction = {
             gasLimit: config.gasLimit,
@@ -131,22 +131,22 @@ const sendTransaction = async function (to, amount, gasPrice) {
             to: to,
             value: amount,
             chainId: chainId
-        };
+        }
     
-        return await wallet.sendTransaction(transaction);
+        return await wallet.sendTransaction(transaction)
     } else {
-        let hash = null;
+        let hash = null
 
-        async function getAddress() { return wallet.address; }
-        async function sign(transaction) { return wallet.sign(transaction); }
+        async function getAddress() { return wallet.address }
+        async function sign(transaction) { return wallet.sign(transaction) }
 
-        async function resolveName(addressOrName) { return await provider.resolveName(addressOrName); }
-        async function estimateGas(transaction) { return await provider.estimateGas(transaction); }
-        async function getGasPrice() { return await provider.getGasPrice(); }
-        async function getTransactionCount(blockTag) { return await provider.getTransactionCount(blockTag); }
+        async function resolveName(addressOrName) { return await provider.resolveName(addressOrName) }
+        async function estimateGas(transaction) { return await provider.estimateGas(transaction) }
+        async function getGasPrice() { return await provider.getGasPrice() }
+        async function getTransactionCount(blockTag) { return await provider.getTransactionCount(blockTag) }
         async function sendTransaction(transaction) {
-            hash = await provider.sendTransaction(transaction);
-            return hash;
+            hash = await provider.sendTransaction(transaction)
+            return hash
         }
         
         const customSigner = {
@@ -161,13 +161,13 @@ const sendTransaction = async function (to, amount, gasPrice) {
             sign: sign
         }
 
-        const tokenContract = config.tokenContracts[config.token];
-        const contractAddress = tokenContract.address;
-        const contract = new Contract(contractAddress, tokenContract.abi, customSigner);
-        const bigNumberAmount = ethers.utils.bigNumberify(amount);
-        await contract.transfer(to, bigNumberAmount);
+        const tokenContract = config.tokenContracts[config.token]
+        const contractAddress = tokenContract.address
+        const contract = new Contract(contractAddress, tokenContract.abi, customSigner)
+        const bigNumberAmount = ethers.utils.bigNumberify(amount)
+        await contract.transfer(to, bigNumberAmount)
 
-        return hash;
+        return hash
     }
 }
 

--- a/bot/index.js
+++ b/bot/index.js
@@ -126,7 +126,7 @@ async function sendTransaction (to, amount, gasPrice) {
     const tokenContract = config.tokenContracts[config.token]
     const contractAddress = tokenContract.address
     const contract = new Contract(contractAddress, tokenContract.abi, customSigner)
-    const bigNumberAmount = ethers.utils.parseUnits(amount.toString())
+    const bigNumberAmount = ethers.utils.parseUnits(amount.toString(), 'ether')
 
     await contract.transfer(to, bigNumberAmount)
 

--- a/bot/index.js
+++ b/bot/index.js
@@ -4,180 +4,155 @@ const ethers = require('ethers')
 const Wallet = ethers.Wallet
 const Contract = ethers.Contract
 const providers = ethers.providers
-const utils = ethers.utils
 
-const prices = require('./prices')
 const config = require('../config')
+const prices = require('./prices')
 const github = require('./github')
 
 const contractAddressString = 'Contract address:'
 
-
 const logger = winston.createLogger({
-    level: 'info',
-    format: winston.format.json(),
-    transports: [
-        new winston.transports.File({ filename: './log/error.log', level: 'error' }),
-        new winston.transports.File({ filename: './log/info.log', level: 'info' }),
-        // new winston.transports.File({ filename: './log/combined.log' })
-    ]
+  level: 'info',
+  format: winston.format.json(),
+  transports: [
+    new winston.transports.File({ filename: './log/error.log', level: 'error' }),
+    new winston.transports.File({ filename: './log/info.log', level: 'info' })
+    // new winston.transports.File({ filename: './log/combined.log' })
+  ]
 })
 
+function needsFunding (req) {
+  if (req.body.action !== 'edited' || !req.body.hasOwnProperty('comment')) {
+    return false
+  } else if (req.body.comment.user.login !== config.githubUsername) {
+    return false
+  } else if (!hasAddress(req)) {
+    return false
+  }
+  return true
+}
 
-const needsFunding = function (req) {
-    if (req.body.action !== 'edited' || !req.body.hasOwnProperty('comment')) {
-        return false
-    } else if (req.body.comment.user.login !== config.githubUsername) {
-        return false
-    } else if (!hasAddress(req)) {
-        return false
-    }
+function hasAddress (req) {
+  const commentBody = req.body.comment.body
+  if (commentBody.search(contractAddressString) === -1) {
+    return false
+  } else {
     return true
+  }
 }
 
-const hasAddress = function (req) {
-    const commentBody = req.body.comment.body
-    if (commentBody.search(contractAddressString) === -1) {
-        return false
-    } else {
-        return true
-    }
+function getAddress (req) {
+  const commentBody = req.body.comment.body
+  const index = commentBody.search(contractAddressString) + 19
+  return commentBody.substring(index, index + 42)
 }
 
-const getAddress = function (req) {
-    const commentBody = req.body.comment.body
-    const index = commentBody.search(contractAddressString) + 19
-    return commentBody.substring(index, index + 42)
+async function getLabel (req) {
+  const labels = await github.getLabels(req)
+  const bountyLabels = labels.filter(label => config.bountyLabels.hasOwnProperty(label.name))
+  if (bountyLabels.length === 1) {
+    return bountyLabels[0]
+  } else {
+    throw new Error('Error getting bounty labels')
+  }
 }
 
-const getLabel = function (req) {
-    return new Promise((resolve, reject) => {
-        github.getLabels(req)
-            .then(labels => {
-                const bountyLabels = labels.filter(label => config.bountyLabels.hasOwnProperty(label.name))
-                if (bountyLabels.length === 1) {
-                    resolve(bountyLabels[0])
-                } else {
-                    reject('Error getting bounty labels')
-                }
-            }).catch(err => {
-                reject(err)
-            })
-    })
+async function getAmount (req) {
+  const label = await getLabel(req)
+  const tokenPrice = await prices.getTokenPrice(config.token)
+
+  const amountToPayDollar = config.priceHour * config.bountyLabels[label.name]
+  return (amountToPayDollar / tokenPrice)
 }
-
-const getAmountMock = function (req) {
-    return new Promise((resolve, reject) => {
-        resolve(10)
-    })
-}
-
-const getAmount = function (req) {
-    return new Promise((resolve, reject) => {
-        const labelPromise = getLabel(req)
-        const tokenPricePromise = prices.getTokenPrice(config.token)
-
-        Promise.all([labelPromise, tokenPricePromise])
-            .then(function (values) {
-                const label = values[0]
-                const tokenPrice = values[1]
-                const amountToPayDollar = config.priceHour * config.bountyLabels[label.name]
-                resolve(amountToPayDollar / tokenPrice)
-            })
-            .catch((err) => {
-                reject(err)
-            })
-    })
-}
-
 
 // Logging functions
 
-const logTransaction = function (tx) {
-    logger.info("[OK] Succesfully funded bounty with transaction " + tx.hash)
-    logger.info(" * From: " + tx.from)
-    logger.info(" * To: " + tx.to)
-    logger.info(" * Amount: " + tx.value)
-    logger.info(" * Gas Price: " + tx.gasPrice)
-    logger.info("====================================================")
+function logTransaction (tx) {
+  logger.info(`[OK] Succesfully funded bounty with transaction ${tx.hash}`)
+  logger.info(` * From: ${tx.from}`)
+  logger.info(` * To: ${tx.to}`)
+  logger.info(` * Amount: ${tx.value}`)
+  logger.info(` * Gas Price: ${tx.gasPrice}`)
+  logger.info(`====================================================`)
 }
 
-const info = function (msg) {
-    logger.info(msg)
+function info (msg) {
+  logger.info(msg)
 }
 
-const error = function (errorMessage) {
-    logger.error("[ERROR] Request processing failed: " + errorMessage)
+function error (errorMessage) {
+  logger.error(`[ERROR] Request processing failed: ${errorMessage}`)
 }
 
+async function sendTransaction (to, amount, gasPrice) {
+  let hash = null
+  let chainId = providers.Provider.chainId.ropsten
+  let chainName = providers.networks.ropsten
 
-const sendTransaction = async function (to, amount, gasPrice) {
-    let chainId = providers.Provider.chainId.ropsten
-    let chainName = providers.networks.ropsten
+  if (config.realTransaction) {
+    chainId = providers.Provider.chainId.homestead
+    chainName = providers.networks.homestead
+  }
 
-    if (config.realTransaction) {
-        chainId = providers.Provider.chainId.homestead
-        chainName = providers.networks.homestead
+  const wallet = new Wallet(config.privateKey)
+  wallet.provider = ethers.providers.getDefaultProvider(chainName)
+
+  if (config.token === 'ETH') {
+    const transaction = {
+      gasLimit: config.gasLimit,
+      gasPrice: gasPrice,
+      to: to,
+      value: amount,
+      chainId: chainId
     }
 
-    const wallet = new Wallet(config.privateKey)
-    const provider = ethers.providers.getDefaultProvider(chainName)
-
-    wallet.provider = provider
-    if (config.token === 'ETH') {
-        const transaction = {
-            gasLimit: config.gasLimit,
-            gasPrice: gasPrice,
-            to: to,
-            value: amount,
-            chainId: chainId
-        }
+    hash = await wallet.sendTransaction(transaction)
+  } else {
+    const customSigner = getCustomSigner(wallet, sendTransaction)
+    const tokenContract = config.tokenContracts[config.token]
+    const contractAddress = tokenContract.address
+    const contract = new Contract(contractAddress, tokenContract.abi, customSigner)
+    const bigNumberAmount = ethers.utils.bigNumberify(amount)
     
-        return await wallet.sendTransaction(transaction)
-    } else {
-        let hash = null
+    await contract.transfer(to, bigNumberAmount)
+  }
 
-        async function getAddress() { return wallet.address }
-        async function sign(transaction) { return wallet.sign(transaction) }
+  return hash
+}
 
-        async function resolveName(addressOrName) { return await provider.resolveName(addressOrName) }
-        async function estimateGas(transaction) { return await provider.estimateGas(transaction) }
-        async function getGasPrice() { return await provider.getGasPrice() }
-        async function getTransactionCount(blockTag) { return await provider.getTransactionCount(blockTag) }
-        async function sendTransaction(transaction) {
-            hash = await provider.sendTransaction(transaction)
-            return hash
-        }
-        
-        const customSigner = {
-            getAddress: getAddress,
-            provider: {
-                resolveName: resolveName,
-                estimateGas: estimateGas,
-                getGasPrice: getGasPrice,
-                getTransactionCount: getTransactionCount,
-                sendTransaction: sendTransaction
-            },
-            sign: sign
-        }
+function getCustomSigner (wallet, sendTransaction) {
+  const provider = wallet.provider
 
-        const tokenContract = config.tokenContracts[config.token]
-        const contractAddress = tokenContract.address
-        const contract = new Contract(contractAddress, tokenContract.abi, customSigner)
-        const bigNumberAmount = ethers.utils.bigNumberify(amount)
-        await contract.transfer(to, bigNumberAmount)
+  async function getAddress () { return wallet.address }
+  async function sign (transaction) { return wallet.sign(transaction) }
 
-        return hash
-    }
+  async function resolveName (addressOrName) { return provider.resolveName(addressOrName) }
+  async function estimateGas (transaction) { return provider.estimateGas(transaction) }
+  async function getGasPrice () { return provider.getGasPrice() }
+  async function getTransactionCount (blockTag) { return provider.getTransactionCount(blockTag) }
+
+  const customSigner = {
+    getAddress: getAddress,
+    provider: {
+      resolveName: resolveName,
+      estimateGas: estimateGas,
+      getGasPrice: getGasPrice,
+      getTransactionCount: getTransactionCount,
+      sendTransaction: sendTransaction
+    },
+    sign: sign
+  }
+
+  return customSigner
 }
 
 module.exports = {
-    needsFunding: needsFunding,
-    getAddress: getAddress,
-    getAmount: getAmount,
-    getGasPrice: prices.getGasPrice,
-    sendTransaction: sendTransaction,
-    info: info,
-    logTransaction: logTransaction,
-    error: error
+  needsFunding: needsFunding,
+  getAddress: getAddress,
+  getAmount: getAmount,
+  getGasPrice: prices.getGasPrice,
+  sendTransaction: sendTransaction,
+  info: info,
+  logTransaction: logTransaction,
+  error: error
 }

--- a/bot/index.js
+++ b/bot/index.js
@@ -91,6 +91,9 @@ async function sendTransaction (to, amount, gasPrice) {
   if (isNaN(amount)) {
     throw Error('Invalid amount')
   }
+  if (!config.privateKey.startsWith('0x')) {
+    throw Error('Private key should start with 0x')
+  }
 
   let transaction = null
   let hash = null

--- a/bot/index.js
+++ b/bot/index.js
@@ -79,9 +79,9 @@ const getAmount = function (req) {
 
         Promise.all([labelPromise, tokenPricePromise])
             .then(function (values) {
-                let label = values[0]
-                let tokenPrice = values[1]
-                let amountToPayDollar = config.priceHour * config.bountyLabels[label.name]
+                const label = values[0]
+                const tokenPrice = values[1]
+                const amountToPayDollar = config.priceHour * config.bountyLabels[label.name]
                 resolve(amountToPayDollar / tokenPrice)
             })
             .catch((err) => {
@@ -112,8 +112,8 @@ const error = function (errorMessage) {
 
 
 const sendTransaction = async function (to, amount, gasPrice) {
-    var chainId = providers.Provider.chainId.ropsten
-    var chainName = providers.networks.ropsten
+    let chainId = providers.Provider.chainId.ropsten
+    let chainName = providers.networks.ropsten
 
     if (config.realTransaction) {
         chainId = providers.Provider.chainId.homestead

--- a/bot/prices.js
+++ b/bot/prices.js
@@ -1,67 +1,67 @@
 "use strict"
 
-const https = require("https");
-const config = require("../config");
+const https = require("https")
+const config = require("../config")
 
 
 const getGasPrice = function () {
-    const url = 'https://ethgasstation.info/json/ethgasAPI.json';
+    const url = 'https://ethgasstation.info/json/ethgasAPI.json'
     // return new pending promise
     return new Promise((resolve, reject) => {
         // select http or https module, depending on reqested url
-        const lib = url.startsWith('https') ? require('https') : require('http');
+        const lib = url.startsWith('https') ? require('https') : require('http')
         const request = lib.get(url, (response) => {
             // handle http errors
             if (response.statusCode < 200 || response.statusCode > 299) {
-                reject('Failed to load page, status code: ' + response.statusCode);
+                reject('Failed to load page, status code: ' + response.statusCode)
             }
             // temporary data holder
-            const body = [];
+            const body = []
             // on every content chunk, push it to the data array
-            response.on('data', (chunk) => body.push(chunk));
+            response.on('data', (chunk) => body.push(chunk))
             // we are done, resolve promise with those joined chunks
             response.on('end', () => {
                 // safeLowWait returns GWei (10^10 Wei).
-                let jsonBody = JSON.parse(body.join(''));
-                let gasPriceWei = parseInt(jsonBody['safeLowWait']) * Math.pow(10, 10);
-                resolve(gasPriceWei);
-            });
-        });
+                let jsonBody = JSON.parse(body.join(''))
+                let gasPriceWei = parseInt(jsonBody['safeLowWait']) * Math.pow(10, 10)
+                resolve(gasPriceWei)
+            })
+        })
         // handle connection errors of the request
-        request.on('error', (err) => reject(err));
+        request.on('error', (err) => reject(err))
     })
-};
+}
 
 const getTokenPriceMock = function () {
-    return new Promise((resolve, reject) => resolve(0.35));
+    return new Promise((resolve, reject) => resolve(0.35))
 }
 
 const getTokenPrice = function (token) {
     if (config.debug) {
-        return getTokenPriceMock();
+        return getTokenPriceMock()
     }
     const currency = 'USD'
-    const url = 'https://min-api.cryptocompare.com/data/price?fsym=' + token + '&tsyms=' + currency;
+    const url = 'https://min-api.cryptocompare.com/data/price?fsym=' + token + '&tsyms=' + currency
     // return new pending promise
     return new Promise((resolve, reject) => {
         // select http or https module, depending on reqested url
-        const lib = url.startsWith('https') ? require('https') : require('http');
+        const lib = url.startsWith('https') ? require('https') : require('http')
         const request = lib.get(url, (response) => {
             // handle http errors
             if (response.statusCode < 200 || response.statusCode > 299) {
-                reject('Failed to load page, status code: ' + response.statusCode);
+                reject('Failed to load page, status code: ' + response.statusCode)
             }
             // temporary data holder
-            const body = [];
+            const body = []
             // on every content chunk, push it to the data array
-            response.on('data', (chunk) => body.push(chunk));
+            response.on('data', (chunk) => body.push(chunk))
             // we are done, resolve promise with those joined chunks
             response.on('end', () => {
-                let jsonBody = JSON.parse(body.join(''));
-                let tokenPrice = parseFloat(jsonBody[currency]);
-                resolve(tokenPrice);
-            });
-        });
+                let jsonBody = JSON.parse(body.join(''))
+                let tokenPrice = parseFloat(jsonBody[currency])
+                resolve(tokenPrice)
+            })
+        })
         // handle connection errors of the request
         request.on('error', (err) => reject(err))
     })

--- a/bot/prices.js
+++ b/bot/prices.js
@@ -1,73 +1,62 @@
-"use strict"
+'use strict'
 
-const https = require("https")
-const config = require("../config")
-
-
-const getGasPrice = function () {
-    const url = 'https://ethgasstation.info/json/ethgasAPI.json'
-    // return new pending promise
-    return new Promise((resolve, reject) => {
-        // select http or https module, depending on reqested url
-        const lib = url.startsWith('https') ? require('https') : require('http')
-        const request = lib.get(url, (response) => {
-            // handle http errors
-            if (response.statusCode < 200 || response.statusCode > 299) {
-                reject('Failed to load page, status code: ' + response.statusCode)
-            }
-            // temporary data holder
-            const body = []
-            // on every content chunk, push it to the data array
-            response.on('data', (chunk) => body.push(chunk))
-            // we are done, resolve promise with those joined chunks
-            response.on('end', () => {
-                // safeLowWait returns GWei (10^10 Wei).
-                const jsonBody = JSON.parse(body.join(''))
-                const gasPriceWei = parseInt(jsonBody['safeLowWait']) * Math.pow(10, 10)
-                resolve(gasPriceWei)
-            })
-        })
-        // handle connection errors of the request
-        request.on('error', (err) => reject(err))
+function getGasPrice () {
+  const url = 'https://ethgasstation.info/json/ethgasAPI.json'
+  // return new pending promise
+  return new Promise((resolve, reject) => {
+    // select http or https module, depending on reqested url
+    const lib = url.startsWith('https') ? require('https') : require('http')
+    const request = lib.get(url, (response) => {
+      // handle http errors
+      if (response.statusCode < 200 || response.statusCode > 299) {
+        reject(new Error(`Failed to load page, status code: ${response.statusCode}`))
+      }
+      // temporary data holder
+      const body = []
+      // on every content chunk, push it to the data array
+      response.on('data', (chunk) => body.push(chunk))
+      // we are done, resolve promise with those joined chunks
+      response.on('end', () => {
+        // safeLowWait returns GWei (10^10 Wei).
+        const jsonBody = JSON.parse(body.join(''))
+        const gasPriceWei = parseInt(jsonBody['safeLowWait']) * Math.pow(10, 10)
+        resolve(gasPriceWei)
+      })
     })
+    // handle connection errors of the request
+    request.on('error', (err) => reject(err))
+  })
 }
 
-const getTokenPriceMock = function () {
-    return new Promise((resolve, reject) => resolve(0.35))
-}
-
-const getTokenPrice = function (token) {
-    if (config.debug) {
-        return getTokenPriceMock()
-    }
-    const currency = 'USD'
-    const url = 'https://min-api.cryptocompare.com/data/price?fsym=' + token + '&tsyms=' + currency
-    // return new pending promise
-    return new Promise((resolve, reject) => {
-        // select http or https module, depending on reqested url
-        const lib = url.startsWith('https') ? require('https') : require('http')
-        const request = lib.get(url, (response) => {
-            // handle http errors
-            if (response.statusCode < 200 || response.statusCode > 299) {
-                reject('Failed to load page, status code: ' + response.statusCode)
-            }
-            // temporary data holder
-            const body = []
-            // on every content chunk, push it to the data array
-            response.on('data', (chunk) => body.push(chunk))
-            // we are done, resolve promise with those joined chunks
-            response.on('end', () => {
-                const jsonBody = JSON.parse(body.join(''))
-                const tokenPrice = parseFloat(jsonBody[currency])
-                resolve(tokenPrice)
-            })
-        })
-        // handle connection errors of the request
-        request.on('error', (err) => reject(err))
+function getTokenPrice (token) {
+  const currency = 'USD'
+  const url = `https://min-api.cryptocompare.com/data/price?fsym=${token}&tsyms=${currency}`
+  // return new pending promise
+  return new Promise((resolve, reject) => {
+    // select http or https module, depending on reqested url
+    const lib = url.startsWith('https') ? require('https') : require('http')
+    const request = lib.get(url, (response) => {
+      // handle http errors
+      if (response.statusCode < 200 || response.statusCode > 299) {
+        reject(new Error(`Failed to load page, status code: ${response.statusCode}`))
+      }
+      // temporary data holder
+      const body = []
+      // on every content chunk, push it to the data array
+      response.on('data', (chunk) => body.push(chunk))
+      // we are done, resolve promise with those joined chunks
+      response.on('end', () => {
+        const jsonBody = JSON.parse(body.join(''))
+        const tokenPrice = parseFloat(jsonBody[currency])
+        resolve(tokenPrice)
+      })
     })
+    // handle connection errors of the request
+    request.on('error', (err) => reject(err))
+  })
 }
 
 module.exports = {
-    getGasPrice: getGasPrice,
-    getTokenPrice: getTokenPrice
+  getGasPrice: getGasPrice,
+  getTokenPrice: getTokenPrice
 }

--- a/bot/prices.js
+++ b/bot/prices.js
@@ -29,6 +29,10 @@ function getGasPrice () {
 }
 
 function getTokenPrice (token) {
+  if (token === 'STT') {
+    return 1
+  }
+
   const currency = 'USD'
   const url = `https://min-api.cryptocompare.com/data/price?fsym=${token}&tsyms=${currency}`
   // return new pending promise

--- a/bot/prices.js
+++ b/bot/prices.js
@@ -22,8 +22,8 @@ const getGasPrice = function () {
             // we are done, resolve promise with those joined chunks
             response.on('end', () => {
                 // safeLowWait returns GWei (10^10 Wei).
-                let jsonBody = JSON.parse(body.join(''))
-                let gasPriceWei = parseInt(jsonBody['safeLowWait']) * Math.pow(10, 10)
+                const jsonBody = JSON.parse(body.join(''))
+                const gasPriceWei = parseInt(jsonBody['safeLowWait']) * Math.pow(10, 10)
                 resolve(gasPriceWei)
             })
         })
@@ -57,8 +57,8 @@ const getTokenPrice = function (token) {
             response.on('data', (chunk) => body.push(chunk))
             // we are done, resolve promise with those joined chunks
             response.on('end', () => {
-                let jsonBody = JSON.parse(body.join(''))
-                let tokenPrice = parseFloat(jsonBody[currency])
+                const jsonBody = JSON.parse(body.join(''))
+                const tokenPrice = parseFloat(jsonBody[currency])
                 resolve(tokenPrice)
             })
         })

--- a/config/default.js
+++ b/config/default.js
@@ -30,7 +30,7 @@ const ERC20_ABI = [
         "payable": false,
         "type": "function"
     }
-];
+]
 
 const TOKEN_CONTRACTS = {
     'STT': {

--- a/config/default.js
+++ b/config/default.js
@@ -53,10 +53,10 @@ module.exports = {
   // URL for the signer
   signerPath: 'https://ropsten.infura.io',
 
-  // Address with the funding for the bounties
+  // Address with the funding for the bounties (hex value starting with 0x)
   sourceAddress: '0x26a4D114B98C4b0B0118426F10fCc1112AA2864d',
 
-  // Private key for ether.js wallet
+  // Private key for ether.js wallet (hex value starting with 0x)
   privateKey: '',
 
   // Token of the currency for fetching real time prices (e.g. 'SNT')

--- a/config/default.js
+++ b/config/default.js
@@ -1,85 +1,85 @@
 // Work hours per label
 const BOUNTY_LABELS = {
-    'bounty-xs': 1,
-    'bounty-s': 10,
-    'bounty-m': 100,
-    'bounty-l': 1000,
-    'bounty-xl': 10000
+  'bounty-xs': 1,
+  'bounty-s': 10,
+  'bounty-m': 100,
+  'bounty-l': 1000,
+  'bounty-xl': 10000
 }
 
 const ERC20_ABI = [
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "name": "_amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "transfer",
-        "outputs": [
-            {
-                "name": "success",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "type": "function"
-    }
+  {
+    'constant': false,
+    'inputs': [
+      {
+        'name': '_to',
+        'type': 'address'
+      },
+      {
+        'name': '_amount',
+        'type': 'uint256'
+      }
+    ],
+    'name': 'transfer',
+    'outputs': [
+      {
+        'name': 'success',
+        'type': 'bool'
+      }
+    ],
+    'payable': false,
+    'type': 'function'
+  }
 ]
 
 const TOKEN_CONTRACTS = {
-    'STT': {
-        address: '0xc55cF4B03948D7EBc8b9E8BAD92643703811d162',
-        abi: ERC20_ABI
-    },
-    'SNT': {
-        address: '0x744d70fdbe2ba4cf95131626614a1763df805b9e',
-        abi: ERC20_ABI
-    }
+  'STT': {
+    address: '0xc55cF4B03948D7EBc8b9E8BAD92643703811d162',
+    abi: ERC20_ABI
+  },
+  'SNT': {
+    address: '0x744d70fdbe2ba4cf95131626614a1763df805b9e',
+    abi: ERC20_ABI
+  }
 }
 
 module.exports = {
-    // Debug mode for testing the bot
-    debug: true,
+  // Debug mode for testing the bot
+  debug: true,
 
-    // URL where the bot is listening (e.g. '/funding')
-    urlEndpoint: '/',
+  // URL where the bot is listening (e.g. '/funding')
+  urlEndpoint: '/',
 
-    // URL for the signer
-    signerPath: 'https://ropsten.infura.io',
+  // URL for the signer
+  signerPath: 'https://ropsten.infura.io',
 
-    // Address with the funding for the bounties
-    sourceAddress: '0x26a4D114B98C4b0B0118426F10fCc1112AA2864d',
+  // Address with the funding for the bounties
+  sourceAddress: '0x26a4D114B98C4b0B0118426F10fCc1112AA2864d',
 
-    // Private key for ether.js wallet
-    privateKey: '',
+  // Private key for ether.js wallet
+  privateKey: '',
 
-    // Token of the currency for fetching real time prices (e.g. 'SNT')
-    token: 'SNT',
+  // Token of the currency for fetching real time prices (e.g. 'SNT')
+  token: 'SNT',
 
-    // Limit for the gas used in a transaction (e.g. 92000)
-    gasLimit: 92000,
+  // Limit for the gas used in a transaction (e.g. 92000)
+  gasLimit: 92000,
 
-    // Price per hour you will pay in dolars (e.g. 35)
-    priceHour: 1,
+  // Price per hour you will pay in dolars (e.g. 35)
+  priceHour: 1,
 
-    // Delay before funding a bounty (e.g. 3600000)
-    delayInMiliSeconds: 10000,
+  // Delay before funding a bounty (e.g. 3600000)
+  delayInMiliSeconds: 10000,
 
-    // Bounty Labels for the issues and the correspondent hours (e.g. {'bounty-xs': 3})
-    bountyLabels: BOUNTY_LABELS,
+  // Bounty Labels for the issues and the correspondent hours (e.g. {'bounty-xs': 3})
+  bountyLabels: BOUNTY_LABELS,
 
-    // Contract info for the different supported tokens
-    tokenContracts: TOKEN_CONTRACTS,
+  // Contract info for the different supported tokens
+  tokenContracts: TOKEN_CONTRACTS,
 
-    // username for the bot which has to comment for starting the process (e.g. status-bounty-)
-    githubUsername: 'status-open-bounty',
+  // username for the bot which has to comment for starting the process (e.g. status-bounty-)
+  githubUsername: 'status-open-bounty',
 
-    // Activate real transactions
-    realTransaction: false
+  // Activate real transactions
+  realTransaction: false
 }

--- a/config/default.js
+++ b/config/default.js
@@ -60,7 +60,7 @@ module.exports = {
   privateKey: '',
 
   // Token of the currency for fetching real time prices (e.g. 'SNT')
-  token: 'SNT',
+  token: 'STT',
 
   // Limit for the gas used in a transaction (e.g. 92000)
   gasLimit: 92000,

--- a/config/index.js
+++ b/config/index.js
@@ -1,4 +1,4 @@
-var _ = require("lodash");
-var defaults = require("./default.js");
-var config = require("./" + (process.env.NODE_ENV || "default") + ".js");
-module.exports = _.merge({}, defaults, config);
+var _ = require("lodash")
+var defaults = require("./default.js")
+var config = require("./" + (process.env.NODE_ENV || "default") + ".js")
+module.exports = _.merge({}, defaults, config)

--- a/config/index.js
+++ b/config/index.js
@@ -1,4 +1,4 @@
-var _ = require("lodash")
-var defaults = require("./default.js")
-var config = require("./" + (process.env.NODE_ENV || "default") + ".js")
+const _ = require("lodash")
+const defaults = require("./default.js")
+const config = require("./" + (process.env.NODE_ENV || "default") + ".js")
 module.exports = _.merge({}, defaults, config)

--- a/config/index.js
+++ b/config/index.js
@@ -1,4 +1,4 @@
-const _ = require("lodash")
-const defaults = require("./default.js")
-const config = require("./" + (process.env.NODE_ENV || "default") + ".js")
+const _ = require('lodash')
+const defaults = require('./default.js')
+const config = require('./' + (process.env.NODE_ENV || 'default') + '.js')
 module.exports = _.merge({}, defaults, config)

--- a/config/index.js
+++ b/config/index.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
 const defaults = require('./default.js')
-const config = require('./' + (process.env.NODE_ENV || 'default') + '.js')
+const configFileName = process.env.NODE_ENV || 'default'
+const config = require(`./${configFileName}.js`)
 module.exports = _.merge({}, defaults, config)

--- a/index.js
+++ b/index.js
@@ -11,110 +11,89 @@ const config = require('./config')
 const bot = require('./bot')
 const crypto = require('crypto')
 
-
-const express = require('express'),
-      cors = require('cors'),
-      helmet = require('helmet'),
-      app = express(),
-      bodyParser = require('body-parser'),
-      jsonParser = bodyParser.json()
+const express = require('express')
+const cors = require('cors')
+const helmet = require('helmet')
+const app = express()
+const bodyParser = require('body-parser')
+const jsonParser = bodyParser.json()
 
 app.use(cors())
 app.use(helmet())
 
 // Receive a POST request at the url specified by an env. var.
 app.post(`${config.urlEndpoint}`, jsonParser, function (req, res, next) {
-    
-    if (!req.body || !req.body.action) {
-        return res.sendStatus(400)
-    } else if (!bot.needsFunding(req)) {
-        return res.sendStatus(204)
-    }
-    validation = validateRequest(req)
+  if (!req.body || !req.body.action) {
+    return res.sendStatus(400)
+  } else if (!bot.needsFunding(req)) {
+    return res.sendStatus(204)
+  }
 
-    if (validation.correct) {
+  const validation = validateRequest(req)
 
-        setTimeout(() => {
-            processRequest(req)
-                .then(() => {
-                    bot.info('issue well funded: ' + req.body.issue.url)
-                })
-                .catch((err) => {
-                    bot.error('Error processing request: ' + req.body.issue.url)
-                    bot.error('Error: ' + err)
-                    bot.error('Dump: ', req.body)
-                })
-        }, config.delayInMiliSeconds)
-
-    } else {
-        bot.error('Error validating issue: ' + req.body.issue.url)
-        bot.error('Error: ' + validation.error)
-    }
-    return res.sendStatus(200)
+  if (validation.correct) {
+    setTimeout(async () => {
+      try {
+        await processRequest(req)
+        bot.info(`issue well funded: ${req.body.issue.url}`)
+      } catch (err) {
+        bot.error(`Error processing request: ${req.body.issue.url}`)
+        bot.error(`Error: ${err}`)
+        bot.error(`Dump: ${req.body}`)
+      }
+    }, config.delayInMiliSeconds)
+  } else {
+    bot.error(`Error validating issue: ${req.body.issue.url}`)
+    bot.error(`Error: ${validation.error}`)
+  }
+  return res.sendStatus(200)
 })
 
-const validateRequest = function (req) {
-    validation = {correct: false, error: ''}
-    webhookSecret = process.env.WEBHOOK_SECRET
+function validateRequest (req) {
+  const validation = { correct: false, error: '' }
+  const webhookSecret = process.env.WEBHOOK_SECRET
 
-    if(!webhookSecret) {
-        validation.error = 'Github Webhook Secret key not found. ' +
-        'Please set env variable WEBHOOK_SECRET to github\'s webhook secret value'
+  if (!webhookSecret) {
+    validation.error = 'Github Webhook Secret key not found. ' +
+                       'Please set env variable WEBHOOK_SECRET to github\'s webhook secret value'
+  } else {
+    const blob = JSON.stringify(req.body)
+    const hmac = crypto.createHmac('sha1', webhookSecret)
+    const ourSignature = `sha1=${hmac.update(blob).digest('hex')}`
+
+    const theirSignature = req.get('X-Hub-Signature')
+
+    const bufferA = Buffer.from(ourSignature, 'utf8')
+    const bufferB = Buffer.from(theirSignature, 'utf8')
+
+    const safe = crypto.timingSafeEqual(bufferA, bufferB)
+
+    if (safe) {
+      validation.correct = true
     } else {
-
-        const blob = JSON.stringify(req.body)
-        const hmac = crypto.createHmac('sha1', webhookSecret)
-        const ourSignature = `sha1=${hmac.update(blob).digest('hex')}`
-
-        const theirSignature = req.get('X-Hub-Signature')
-
-        const bufferA = Buffer.from(ourSignature, 'utf8')
-        const bufferB = Buffer.from(theirSignature, 'utf8')
-
-        const safe = crypto.timingSafeEqual(bufferA, bufferB)
-
-        if (safe) {
-            validation.correct = true
-        } else {
-            validation.error = 'Invalid signature. Check that WEBHOOK_SECRET ' +
-            'env variable matches github\'s webhook secret value'
-        }
+      validation.error = 'Invalid signature. Check that WEBHOOK_SECRET ' +
+                         'env variable matches github\'s webhook secret value'
     }
+  }
 
-    return validation
+  return validation
 }
 
-const processRequest = function (req) {
-    // const wallet = bot.wallet
+async function processRequest (req) {
+  // const wallet = bot.wallet
 
-    const from = config.sourceAddress
-    const to = bot.getAddress(req)
+  const to = bot.getAddress(req)
 
-    // Asynchronous requests for Gas Price and Amount
-    const amountPromise = bot.getAmount(req)
-    const gasPricePromise = bot.getGasPrice()
-    return new Promise((resolve, reject) => {
-        Promise.all([amountPromise, gasPricePromise])
-            .then(function (results) {
-                const amount = results[0]
-                const gasPrice = results[1]
+  // Asynchronous requests for Gas Price and Amount
+  const amount = await bot.getAmount(req)
+  const gasPrice = await bot.getGasPrice()
 
-                bot.sendTransaction(to, amount, gasPrice)
-                    .then(function (hash) {
-                        bot.logTransaction(hash)
-                        resolve()
-                    })
-                    .catch(function (err) {
-                        reject(err)
-                    })
-            })
-            .catch(function (err) {
-                reject(err)
-            })
-    })
+  const hash = await bot.sendTransaction(to, amount, gasPrice)
+
+  bot.logTransaction(hash)
 }
 
 const port = process.env.PORT || 8181
 app.listen(port, function () {
-    bot.info('Autobounty listening on port', port)
+  bot.info('Autobounty listening on port', port)
 })

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@
 * Depends on commiteth version as of 2017-06-10.
 */
 
-const config = require('./config');
-const bot = require('./bot');
-const crypto = require('crypto');
+const config = require('./config')
+const bot = require('./bot')
+const crypto = require('crypto')
 
 
 var express = require('express'),
@@ -17,104 +17,104 @@ var express = require('express'),
     helmet = require('helmet'),
     app = express(),
     bodyParser = require('body-parser'),
-    jsonParser = bodyParser.json();
+    jsonParser = bodyParser.json()
 
-app.use(cors());
-app.use(helmet());
+app.use(cors())
+app.use(helmet())
 
 // Receive a POST request at the url specified by an env. var.
 app.post(`${config.urlEndpoint}`, jsonParser, function (req, res, next) {
     
     if (!req.body || !req.body.action) {
-        return res.sendStatus(400);
+        return res.sendStatus(400)
     } else if (!bot.needsFunding(req)) {
-        return res.sendStatus(204);
+        return res.sendStatus(204)
     }
-    validation = validateRequest(req);
+    validation = validateRequest(req)
 
     if (validation.correct) {
 
         setTimeout(() => {
             processRequest(req)
                 .then(() => {
-                    bot.info('issue well funded: ' + req.body.issue.url);
+                    bot.info('issue well funded: ' + req.body.issue.url)
                 })
                 .catch((err) => {
-                    bot.error('Error processing request: ' + req.body.issue.url);
-                    bot.error('Error: ' + err);
-                    bot.error('Dump: ', req.body);
-                });
-        }, config.delayInMiliSeconds);
+                    bot.error('Error processing request: ' + req.body.issue.url)
+                    bot.error('Error: ' + err)
+                    bot.error('Dump: ', req.body)
+                })
+        }, config.delayInMiliSeconds)
 
     } else {
-        bot.error('Error validating issue: ' + req.body.issue.url);
-        bot.error('Error: ' + validation.error);
+        bot.error('Error validating issue: ' + req.body.issue.url)
+        bot.error('Error: ' + validation.error)
     }
-    return res.sendStatus(200);
-});
+    return res.sendStatus(200)
+})
 
 const validateRequest = function (req) {
-    validation = {correct: false, error: ''};
-    webhookSecret = process.env.WEBHOOK_SECRET;
+    validation = {correct: false, error: ''}
+    webhookSecret = process.env.WEBHOOK_SECRET
 
     if(!webhookSecret) {
         validation.error = 'Github Webhook Secret key not found. ' +
-        'Please set env variable WEBHOOK_SECRET to github\'s webhook secret value';
+        'Please set env variable WEBHOOK_SECRET to github\'s webhook secret value'
     } else {
 
-        const blob = JSON.stringify(req.body);
-        const hmac = crypto.createHmac('sha1', webhookSecret);
-        const ourSignature = `sha1=${hmac.update(blob).digest('hex')}`;
+        const blob = JSON.stringify(req.body)
+        const hmac = crypto.createHmac('sha1', webhookSecret)
+        const ourSignature = `sha1=${hmac.update(blob).digest('hex')}`
 
-        const theirSignature = req.get('X-Hub-Signature');
+        const theirSignature = req.get('X-Hub-Signature')
 
-        const bufferA = Buffer.from(ourSignature, 'utf8');
-        const bufferB = Buffer.from(theirSignature, 'utf8');
+        const bufferA = Buffer.from(ourSignature, 'utf8')
+        const bufferB = Buffer.from(theirSignature, 'utf8')
 
-        const safe = crypto.timingSafeEqual(bufferA, bufferB);
+        const safe = crypto.timingSafeEqual(bufferA, bufferB)
 
         if (safe) {
-            validation.correct = true;
+            validation.correct = true
         } else {
             validation.error = 'Invalid signature. Check that WEBHOOK_SECRET ' +
-            'env variable matches github\'s webhook secret value';
+            'env variable matches github\'s webhook secret value'
         }
     }
 
-    return validation;
+    return validation
 }
 
 const processRequest = function (req) {
-    // const wallet = bot.wallet;
+    // const wallet = bot.wallet
 
-    const from = config.sourceAddress;
-    const to = bot.getAddress(req);
+    const from = config.sourceAddress
+    const to = bot.getAddress(req)
 
     // Asynchronous requests for Gas Price and Amount
-    const amountPromise = bot.getAmount(req);
-    const gasPricePromise = bot.getGasPrice();
+    const amountPromise = bot.getAmount(req)
+    const gasPricePromise = bot.getGasPrice()
     return new Promise((resolve, reject) => {
         Promise.all([amountPromise, gasPricePromise])
             .then(function (results) {
-                const amount = results[0];
-                const gasPrice = results[1];
+                const amount = results[0]
+                const gasPrice = results[1]
 
                 bot.sendTransaction(to, amount, gasPrice)
                     .then(function (hash) {
-                        bot.logTransaction(hash);
-                        resolve();
+                        bot.logTransaction(hash)
+                        resolve()
                     })
                     .catch(function (err) {
-                        reject(err);
-                    });
+                        reject(err)
+                    })
             })
             .catch(function (err) {
-                reject(err);
-            });
-    });
+                reject(err)
+            })
+    })
 }
 
 const port = process.env.PORT || 8181
 app.listen(port, function () {
-    bot.info('Autobounty listening on port', port);
-});
+    bot.info('Autobounty listening on port', port)
+})

--- a/index.js
+++ b/index.js
@@ -12,12 +12,12 @@ const bot = require('./bot')
 const crypto = require('crypto')
 
 
-var express = require('express'),
-    cors = require('cors'),
-    helmet = require('helmet'),
-    app = express(),
-    bodyParser = require('body-parser'),
-    jsonParser = bodyParser.json()
+const express = require('express'),
+      cors = require('cors'),
+      helmet = require('helmet'),
+      app = express(),
+      bodyParser = require('body-parser'),
+      jsonParser = bodyParser.json()
 
 app.use(cors())
 app.use(helmet())

--- a/index.js
+++ b/index.js
@@ -80,14 +80,9 @@ function validateRequest (req) {
 }
 
 async function processRequest (req) {
-  // const wallet = bot.wallet
-
   const to = bot.getAddress(req)
-
-  // Asynchronous requests for Gas Price and Amount
   const amount = await bot.getAmount(req)
   const gasPrice = await bot.getGasPrice()
-
   const hash = await bot.sendTransaction(to, amount, gasPrice)
 
   bot.logTransaction(hash)

--- a/index.js
+++ b/index.js
@@ -38,8 +38,8 @@ app.post(`${config.urlEndpoint}`, jsonParser, function (req, res, next) {
         bot.info(`issue well funded: ${req.body.issue.url}`)
       } catch (err) {
         bot.error(`Error processing request: ${req.body.issue.url}`)
-        bot.error(`Error: ${err}`)
-        bot.error(`Dump: ${req.body}`)
+        bot.error(err)
+        bot.error(`Dump: ${JSON.stringify(req.body)}`)
       }
     }, config.delayInMiliSeconds)
   } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2540 @@
+{
+  "name": "autobounty",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "acorn": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "requires": {
+        "lodash": "4.17.5"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bignumber.js": {
+      "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "body-parser": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.16"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+    },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "color": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
+      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
+      "requires": {
+        "color-convert": "0.5.3",
+        "color-string": "0.3.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "colornames": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
+      "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE="
+    },
+    "colors": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
+      "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg=="
+    },
+    "colorspace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
+      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
+      "requires": {
+        "color": "0.8.0",
+        "text-hex": "0.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+      "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5",
+        "typedarray": "0.0.6"
+      }
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "content-security-policy-builder": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.0.0.tgz",
+      "integrity": "sha512-j+Nhmj1yfZAikJLImCvPJFE29x/UuBi+/MWqggGGc515JKaZrjuei2RhULJmy0MsstW3E3htl002bwmBNMKr7w=="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "vary": "1.1.2"
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.2",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
+      }
+    },
+    "crypto-js": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
+      "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
+    },
+    "dasherize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
+      "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "diagnostics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz",
+      "integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o=",
+      "requires": {
+        "colorspace": "1.0.1",
+        "enabled": "1.0.2",
+        "kuler": "0.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "dns-prefetch-control": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dns-prefetch-control/-/dns-prefetch-control-0.1.0.tgz",
+      "integrity": "sha1-YN20V3dOF48flBXwyrsOhbCzALI="
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2"
+      }
+    },
+    "dont-sniff-mimetype": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.0.0.tgz",
+      "integrity": "sha1-WTKJDcn04vGeXrAqIAJuXl78j1g="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "elliptic": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+      "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+      "requires": {
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "inherits": "2.0.3"
+      }
+    },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.4"
+      }
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "env-variable": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
+      "integrity": "sha512-+jpGxSWG4vr6gVxUHOc4p+ilPnql7NzZxOZBxNldsKGjCF+97df3CbuX7XMaDa5oAVkKQj4rKp38rYdC4VcpDg=="
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.0.tgz",
+      "integrity": "sha512-r83L5CuqaocDvfwdojbz68b6tCUk8KJkqfppO+gmSAQqYCzTr0bCSMu6A6yFCLKG65j5eKcKUw4Cw4Yl4gfWkg==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.3.2",
+        "concat-stream": "1.6.1",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.3.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.11.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "regexpp": "1.0.1",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-standard": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
+      "integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "resolve": "1.5.0"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
+      "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
+      "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+      "dev": true,
+      "requires": {
+        "ignore": "3.3.7",
+        "minimatch": "3.0.4",
+        "resolve": "1.5.0",
+        "semver": "5.5.0"
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
+      "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
+      "dev": true
+    },
+    "eslint-plugin-standard": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
+      "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.3",
+        "acorn-jsx": "3.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "ethers": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-2.2.6.tgz",
+      "integrity": "sha512-DU+WbhXIGP/wFDYFuiZXSr170MFQpRuzjwDRT/FNX1g22nB9JHDlP70/CE+7DtLJdFD+8wvV5QqrnCjMQmTjVg==",
+      "requires": {
+        "ethers-contracts": "2.2.1",
+        "ethers-providers": "2.1.19",
+        "ethers-utils": "2.1.11",
+        "ethers-wallet": "2.1.8"
+      }
+    },
+    "ethers-contracts": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ethers-contracts/-/ethers-contracts-2.2.1.tgz",
+      "integrity": "sha512-3fT2gyhoDhqp/bgaBOenmyu74dDGGO9adkBaOtEuNmFq0Yf4nwynYWJv++rDxe6Z5Dl5cBF304GhnJUVFVlfCA==",
+      "requires": {
+        "ethers-utils": "2.1.11"
+      }
+    },
+    "ethers-providers": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/ethers-providers/-/ethers-providers-2.1.19.tgz",
+      "integrity": "sha512-usjJ5qyGO84kMmIYImwGhJo12nnG5uzqpZlViYQFEfwBzqoj7b9e55xnc7fP6XWcnPrrbMqIa0KrW8BKy9bYpg==",
+      "requires": {
+        "ethers-utils": "2.1.11",
+        "inherits": "2.0.1",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        }
+      }
+    },
+    "ethers-utils": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/ethers-utils/-/ethers-utils-2.1.11.tgz",
+      "integrity": "sha512-BfkGStBmmLjhTldmp5lifiwUeDjx/yowoWfmUnnvPNsix5PFE8IXQdY5VT/Qo1SXMgxzCe8m0Z8ysUw6Q9OmAw==",
+      "requires": {
+        "bn.js": "4.11.8",
+        "hash.js": "1.1.3",
+        "js-sha3": "0.5.7",
+        "xmlhttprequest": "1.8.0"
+      }
+    },
+    "ethers-wallet": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/ethers-wallet/-/ethers-wallet-2.1.8.tgz",
+      "integrity": "sha512-RRISXGCnaFj35WDTyj4Z8UlVkiNep05b7fApON9Ao9y096VhY8/H2w3reGB2VAWIQBM1ZcAY9W67hhMfb5+Prw==",
+      "requires": {
+        "aes-js": "3.0.0",
+        "elliptic": "6.3.3",
+        "ethers-utils": "2.1.11",
+        "scrypt-js": "2.0.3",
+        "setimmediate": "1.0.4",
+        "uuid": "2.0.1"
+      }
+    },
+    "ethjs-format": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/ethjs-format/-/ethjs-format-0.1.8.tgz",
+      "integrity": "sha1-kl7N2WXqcqKi2vKhIuW/gLWtUio=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "ethjs-schema": "0.1.4",
+        "ethjs-util": "0.1.3",
+        "is-hex-prefixed": "1.0.0",
+        "number-to-bn": "1.7.0",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
+    },
+    "ethjs-provider-http": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-provider-http/-/ethjs-provider-http-0.1.6.tgz",
+      "integrity": "sha1-HsXZtL4lfvHValALIqdBmF6IlCA=",
+      "requires": {
+        "xhr2": "0.1.3"
+      }
+    },
+    "ethjs-provider-signer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ethjs-provider-signer/-/ethjs-provider-signer-0.1.4.tgz",
+      "integrity": "sha1-a9XLOKjVsN30asHiOmDuoXFhca4=",
+      "requires": {
+        "ethjs-provider-http": "0.1.6",
+        "ethjs-rpc": "0.1.2"
+      }
+    },
+    "ethjs-query": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/ethjs-query/-/ethjs-query-0.2.9.tgz",
+      "integrity": "sha1-om5rTzhpnpLzSyGE51x4lDKcQvE=",
+      "requires": {
+        "ethjs-format": "0.2.2",
+        "ethjs-rpc": "0.1.5"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "ethjs-format": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/ethjs-format/-/ethjs-format-0.2.2.tgz",
+          "integrity": "sha1-1zs6YFwuElcHn3B3/VRI6ZjOD80=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "ethjs-schema": "0.1.5",
+            "ethjs-util": "0.1.3",
+            "is-hex-prefixed": "1.0.0",
+            "number-to-bn": "1.7.0",
+            "strip-hex-prefix": "1.0.0"
+          }
+        },
+        "ethjs-rpc": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/ethjs-rpc/-/ethjs-rpc-0.1.5.tgz",
+          "integrity": "sha1-CZ4i8n3EwYtpeKSF/DaxsPeWkIA="
+        },
+        "ethjs-schema": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.1.5.tgz",
+          "integrity": "sha1-WXQOOzl3vNu5sRvDBoIB6Kzquw0="
+        }
+      }
+    },
+    "ethjs-rpc": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ethjs-rpc/-/ethjs-rpc-0.1.2.tgz",
+      "integrity": "sha1-OaNFa1HFmu6vtbpVZYmlny2ojSY=",
+      "requires": {
+        "ethjs-format": "0.1.8"
+      }
+    },
+    "ethjs-schema": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ethjs-schema/-/ethjs-schema-0.1.4.tgz",
+      "integrity": "sha1-AyOhYzOxrOmo8daWpu5jRI/dRV8="
+    },
+    "ethjs-signer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ethjs-signer/-/ethjs-signer-0.1.1.tgz",
+      "integrity": "sha1-Cvd5YeKe5FhgOqvTZguIaNM4ZEE=",
+      "requires": {
+        "elliptic": "6.3.2",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.1.0",
+        "rlp": "2.0.0",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.3.2",
+          "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
+          "integrity": "sha1-5MgeCCnPCmWrcOmYuCMnI7XBvEg=",
+          "requires": {
+            "bn.js": "4.11.8",
+            "brorand": "1.1.0",
+            "hash.js": "1.1.3",
+            "inherits": "2.0.3"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+          "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
+        },
+        "number-to-bn": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.1.0.tgz",
+          "integrity": "sha1-UaM4fFvGgDWrQFjGJhMvdn2dCL8=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "is-hex-prefixed": "1.0.0",
+            "strip-hex-prefix": "1.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+            }
+          }
+        }
+      }
+    },
+    "ethjs-util": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.3.tgz",
+      "integrity": "sha1-39XqSkANxeQhqInK9H4IGtp4u1U=",
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
+      }
+    },
+    "expect-ct": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/expect-ct/-/expect-ct-0.1.0.tgz",
+      "integrity": "sha1-UnNWeN4YUwiQ2Ne5XwrGNkCVgJQ="
+    },
+    "express": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+      "requires": {
+        "accepts": "1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.3",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        }
+      }
+    },
+    "external-editor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "dev": true,
+      "requires": {
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "frameguard": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/frameguard/-/frameguard-3.0.0.tgz",
+      "integrity": "sha1-e8rUae57lukdEs6zlZx4I1qScuk="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "globals": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+      "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "hash.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "helmet": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.12.0.tgz",
+      "integrity": "sha512-CgkctpvreQLL6X3EL2Igs/92+75ZFIsrob9/Rdwf2hQCBGH/DxLk4xFPxAAl6jYnnus/YXfFEVXHEJf8TJTwlA==",
+      "requires": {
+        "dns-prefetch-control": "0.1.0",
+        "dont-sniff-mimetype": "1.0.0",
+        "expect-ct": "0.1.0",
+        "frameguard": "3.0.0",
+        "helmet-csp": "2.7.0",
+        "hide-powered-by": "1.0.0",
+        "hpkp": "2.0.0",
+        "hsts": "2.1.0",
+        "ienoopen": "1.0.0",
+        "nocache": "2.0.0",
+        "referrer-policy": "1.1.0",
+        "x-xss-protection": "1.1.0"
+      }
+    },
+    "helmet-csp": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.7.0.tgz",
+      "integrity": "sha512-IGIAkWnxjRbgMXFA2/kmDqSIrIaSfZ6vhMHlSHw7jm7Gm9nVVXqwJ2B1YEpYrJsLrqY+w2Bbimk7snux9+sZAw==",
+      "requires": {
+        "camelize": "1.0.0",
+        "content-security-policy-builder": "2.0.0",
+        "dasherize": "2.0.0",
+        "lodash.reduce": "4.6.0",
+        "platform": "1.3.5"
+      }
+    },
+    "hide-powered-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.0.0.tgz",
+      "integrity": "sha1-SoWtZYgfYoV/xwr3F0oRhNzM4ys="
+    },
+    "hosted-git-info": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "dev": true
+    },
+    "hpkp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hpkp/-/hpkp-2.0.0.tgz",
+      "integrity": "sha1-EOFCJk52IVpdMMROxD3mTe5tFnI="
+    },
+    "hsts": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.1.0.tgz",
+      "integrity": "sha512-zXhh/DqgrTXJ7erTN6Fh5k/xjMhDGXCqdYN3wvxUvGUQvnxcFfUd8E+6vLg/nk3ss1TYMb+DhRl25fYABioTvA=="
+    },
+    "http-errors": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "ienoopen": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.0.0.tgz",
+      "integrity": "sha1-NGpCj0dKrI9QzzeE6i0PFvYr2ms="
+    },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.1.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.5",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      }
+    },
+    "ipaddr.js": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-hex-prefixed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "js-sha3": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "kuler": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
+      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
+      "requires": {
+        "colornames": "0.0.2"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+    },
+    "logform": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-1.3.0.tgz",
+      "integrity": "sha512-U0BBmCbktfbJvQ/q/3JbgGuNi5v0OajbEtuzgUYcxBVtYk6nC1EsNBrEdDQild558PeRRW6q3FcecY6fYVW52Q==",
+      "requires": {
+        "colors": "1.2.1",
+        "fecha": "2.3.3"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.4.tgz",
+      "integrity": "sha512-nMOpAPFosU1B4Ix1jdhx5e3q7XO55ic5a8cgYvW27CequcEY+BabS0kUVL1Cw1V5PuVHZWeNRWFLmEPexo79VA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "nocache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.0.0.tgz",
+      "integrity": "sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA="
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
+      }
+    },
+    "number-to-bn": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.2.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "1.2.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0"
+      }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.6.0"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      }
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "referrer-policy": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/referrer-policy/-/referrer-policy-1.1.0.tgz",
+      "integrity": "sha1-NXdOtzW/UPtsB46DM0tHI1AgfXk="
+    },
+    "regexpp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.0.1.tgz",
+      "integrity": "sha512-8Ph721maXiOYSLtaDGKVmDn5wdsNaF6Px85qFNeMPQq0r8K5Y10tgP6YuR65Ws35n4DvzFcCxEnRNBIXQunzLw==",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "rlp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
+      "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A="
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "scrypt-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+      "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "requires": {
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.2"
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+      "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "statuses": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-hex-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+      "requires": {
+        "is-hex-prefixed": "1.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.3.2",
+        "lodash": "4.17.5",
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      }
+    },
+    "text-hex": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
+      "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "triple-beam": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.1.0.tgz",
+      "integrity": "sha1-KsOHyMS9BL0mxh34kaYHn4WS/hA="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.18"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utf8": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
+      }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "web3": {
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
+      "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
+      "requires": {
+        "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+        "crypto-js": "3.1.8",
+        "utf8": "2.1.2",
+        "xhr2": "0.1.3",
+        "xmlhttprequest": "1.8.0"
+      }
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "winston": {
+      "version": "3.0.0-rc3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.0.0-rc3.tgz",
+      "integrity": "sha512-KPvs53IB5m6wMHAm4j5DgL8MkgfXZKjwNqzTr3IA8SijHTXeN6l8ebyR24rlCSVotuqtXhooFHvYLbA3fAViSw==",
+      "requires": {
+        "async": "2.6.0",
+        "diagnostics": "1.1.0",
+        "isstream": "0.1.2",
+        "logform": "1.3.0",
+        "one-time": "0.0.4",
+        "stack-trace": "0.0.10",
+        "triple-beam": "1.1.0",
+        "winston-transport": "3.0.1"
+      }
+    },
+    "winston-transport": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-3.0.1.tgz",
+      "integrity": "sha1-gAixXu9WYMT7P6CU1YzL0IUoxY0="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "x-xss-protection": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.1.0.tgz",
+      "integrity": "sha512-rx3GzJlgEeZ08MIcDsU2vY2B1QEriUKJTSiNHHUIem6eg9pzVOr2TL3Y4Pd6TMAM5D5azGjcxqI62piITBDHVg=="
+    },
+    "xhr2": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.3.tgz",
+      "integrity": "sha1-y/xHWaabSoiOeM9PILBRA4dXvRE="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -817,31 +817,19 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "ethers": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-2.2.6.tgz",
-      "integrity": "sha512-DU+WbhXIGP/wFDYFuiZXSr170MFQpRuzjwDRT/FNX1g22nB9JHDlP70/CE+7DtLJdFD+8wvV5QqrnCjMQmTjVg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-3.0.7.tgz",
+      "integrity": "sha512-dGRRAaPzvbInGYBGYarYmz6ESjR52AtIiAP7PAZFbcOOmbyqmFVcvVqNiBU5SihK2ER6Va4HwNevOIoI/AzLgw==",
       "requires": {
-        "ethers-contracts": "2.2.1",
-        "ethers-providers": "2.1.19",
-        "ethers-utils": "2.1.11",
-        "ethers-wallet": "2.1.8"
-      }
-    },
-    "ethers-contracts": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ethers-contracts/-/ethers-contracts-2.2.1.tgz",
-      "integrity": "sha512-3fT2gyhoDhqp/bgaBOenmyu74dDGGO9adkBaOtEuNmFq0Yf4nwynYWJv++rDxe6Z5Dl5cBF304GhnJUVFVlfCA==",
-      "requires": {
-        "ethers-utils": "2.1.11"
-      }
-    },
-    "ethers-providers": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/ethers-providers/-/ethers-providers-2.1.19.tgz",
-      "integrity": "sha512-usjJ5qyGO84kMmIYImwGhJo12nnG5uzqpZlViYQFEfwBzqoj7b9e55xnc7fP6XWcnPrrbMqIa0KrW8BKy9bYpg==",
-      "requires": {
-        "ethers-utils": "2.1.11",
+        "aes-js": "3.0.0",
+        "bn.js": "4.11.8",
+        "elliptic": "6.3.3",
+        "hash.js": "1.1.3",
         "inherits": "2.0.1",
+        "js-sha3": "0.5.7",
+        "scrypt-js": "2.0.3",
+        "setimmediate": "1.0.4",
+        "uuid": "2.0.1",
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
@@ -850,30 +838,6 @@
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         }
-      }
-    },
-    "ethers-utils": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/ethers-utils/-/ethers-utils-2.1.11.tgz",
-      "integrity": "sha512-BfkGStBmmLjhTldmp5lifiwUeDjx/yowoWfmUnnvPNsix5PFE8IXQdY5VT/Qo1SXMgxzCe8m0Z8ysUw6Q9OmAw==",
-      "requires": {
-        "bn.js": "4.11.8",
-        "hash.js": "1.1.3",
-        "js-sha3": "0.5.7",
-        "xmlhttprequest": "1.8.0"
-      }
-    },
-    "ethers-wallet": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/ethers-wallet/-/ethers-wallet-2.1.8.tgz",
-      "integrity": "sha512-RRISXGCnaFj35WDTyj4Z8UlVkiNep05b7fApON9Ao9y096VhY8/H2w3reGB2VAWIQBM1ZcAY9W67hhMfb5+Prw==",
-      "requires": {
-        "aes-js": "3.0.0",
-        "elliptic": "6.3.3",
-        "ethers-utils": "2.1.11",
-        "scrypt-js": "2.0.3",
-        "setimmediate": "1.0.4",
-        "uuid": "2.0.1"
       }
     },
     "ethjs-format": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.17.2",
-    "chai": "^4.1.2",
     "cors": "^2.8.1",
-    "eslint": "^4.15.0",
     "ethers": "^2.2.6",
     "ethjs-provider-signer": "^0.1.4",
     "ethjs-query": "^0.2.4",
@@ -22,8 +20,17 @@
     "express": "^4.15.2",
     "helmet": "^3.9.0",
     "lodash": "^4.17.4",
-    "mocha": "^5.0.0",
     "web3": "^0.18.2",
     "winston": "^3.0.0-rc1"
+  },
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "eslint": "^4.19.0",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-promise": "^3.7.0",
+    "eslint-plugin-standard": "^3.0.1",
+    "mocha": "^5.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
   "dependencies": {
     "body-parser": "^1.17.2",
     "cors": "^2.8.1",
-    "ethers": "^2.2.6",
-    "ethjs-provider-signer": "^0.1.4",
-    "ethjs-query": "^0.2.4",
-    "ethjs-signer": "^0.1.1",
+    "ethers": "^3.0",
+    "ethjs-provider-signer": "^0.1",
+    "ethjs-query": "^0.2",
+    "ethjs-signer": "^0.1",
     "express": "^4.15.2",
     "helmet": "^3.9.0",
     "lodash": "^4.17.4",
     "web3": "^0.18.2",
-    "winston": "^3.0.0-rc1"
+    "winston": "^3.0.0-rc3"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/test/test_bot.js
+++ b/test/test_bot.js
@@ -5,52 +5,51 @@ const should = require('chai').should
 const config = require('../config')
 const bot = require('../bot')
 
-
 // status-open-bounty comment from https://github.com/status-im/autobounty/issues/1
-const sob_comment = 'Current balance: 0.000000 ETH\nTokens: SNT: 2500.00 ANT: 25.00\nContract address: 0x3645fe42b1a744ad98cc032c22472388806f86f9\nNetwork: Mainnet\n To claim this bounty sign up at https://openbounty.status.im and make sure to update your Ethereum address in My Payment Details so that the bounty is correctly allocated.\nTo fund it, send ETH or ERC20/ERC223 tokens to the contract address.'
+const sobComment = 'Current balance: 0.000000 ETH\nTokens: SNT: 2500.00 ANT: 25.00\nContract address: 0x3645fe42b1a744ad98cc032c22472388806f86f9\nNetwork: Mainnet\n To claim this bounty sign up at https://openbounty.status.im and make sure to update your Ethereum address in My Payment Details so that the bounty is correctly allocated.\nTo fund it, send ETH or ERC20/ERC223 tokens to the contract address.'
 
 // Fake requests
 const requests = [
-    { body: { action: 'created', comment: { body: 'Creating my first comment', user: { login: 'randomUser' } } } },
-    { body: { action: 'edited', comment: { body: 'Editing my comment', user: { login: 'RandomUser' } } } },
-    { body: { action: 'edited', comment: { body: sob_comment, user: { login: 'status-open-bounty' } } } },
-    { body: { action: 'created', issue: { labels: ['bounty', 'bounty-s'] }, comment: { body: sob_comment, user: { login: 'status-open-bounty' } } } }
+  { body: { action: 'created', comment: { body: 'Creating my first comment', user: { login: 'randomUser' } } } },
+  { body: { action: 'edited', comment: { body: 'Editing my comment', user: { login: 'RandomUser' } } } },
+  { body: { action: 'edited', comment: { body: sobComment, user: { login: 'status-open-bounty' } } } },
+  { body: { action: 'created', issue: { labels: ['bounty', 'bounty-s'] }, comment: { body: sobComment, user: { login: 'status-open-bounty' } } } }
 ]
 
 describe('Bot behavior', function () {
-    describe('#needsFunding()', function () {
-        it('should return false because the comment is not from status-open-bounty', function () {
-            assert.isFalse(bot.needsFunding(requests[0]))
-        })
-        it('should return false because a user is editing a comment', function () {
-            assert.isFalse(bot.needsFunding(requests[1]))
-        })
-        it('should return false because status-open-bounty edited a comment', function () {
-            assert.isFalse(bot.needsFunding(requests[2]))
-        })
-        it('should return true, it is all right and we should fund', function () {
-            assert.isTrue(bot.needsFunding(requests[3]))
-        })
+  describe('#needsFunding()', function () {
+    it('should return false because the comment is not from status-open-bounty', function () {
+      assert.isFalse(bot.needsFunding(requests[0]))
     })
+    it('should return false because a user is editing a comment', function () {
+      assert.isFalse(bot.needsFunding(requests[1]))
+    })
+    it('should return false because status-open-bounty edited a comment', function () {
+      assert.isFalse(bot.needsFunding(requests[2]))
+    })
+    it('should return true, it is all right and we should fund', function () {
+      assert.isTrue(bot.needsFunding(requests[3]))
+    })
+  })
 
-    describe('#getAddress', function () {
-        it('should return the address from a status-open-bounty bot comment', function () {
-            assert.equal(bot.getAddress(requests[3]), '0x3645fe42b1a744ad98cc032c22472388806f86f9')
-        })
+  describe('#getAddress', function () {
+    it('should return the address from a status-open-bounty bot comment', function () {
+      assert.equal(bot.getAddress(requests[3]), '0x3645fe42b1a744ad98cc032c22472388806f86f9')
     })
+  })
 
-    describe('#getAmount', function () {
-        it('should return the amount for the issue given the price per hour and the bounty label for this issue', (done) => {
-            bot.getAmount(requests[3])
-                .then(function (amount) {
-                    const label = 'bounty-s'
-                    const tokenPrice = 0.35
-                    const priceInDollars = config.priceHour * config.bountyLabels[label]
-                    expected_amount = priceInDollars / tokenPrice
-                    assert.equal(amount, expected_amount)
-                    done()
-                })
-                .catch(() => { console.log('error'), done() })
+  describe('#getAmount', function () {
+    it('should return the amount for the issue given the price per hour and the bounty label for this issue', (done) => {
+      bot.getAmount(requests[3])
+        .then(function (amount) {
+          const label = 'bounty-s'
+          const tokenPrice = 0.35
+          const priceInDollars = config.priceHour * config.bountyLabels[label]
+          expected_amount = priceInDollars / tokenPrice
+          assert.equal(amount, expected_amount)
+          done()
         })
+        .catch(() => { console.log('error'), done() })
     })
+  })
 })

--- a/test/test_bot.js
+++ b/test/test_bot.js
@@ -1,7 +1,7 @@
-const chai = require('chai');
-const expect = require('chai').expect;
-const assert = require('chai').assert;
-const should = require('chai').should;
+const chai = require('chai')
+const expect = require('chai').expect
+const assert = require('chai').assert
+const should = require('chai').should
 const config = require('../config')
 const bot = require('../bot')
 
@@ -15,42 +15,42 @@ let requests = [
     { body: { action: 'edited', comment: { body: 'Editing my comment', user: { login: 'RandomUser' } } } },
     { body: { action: 'edited', comment: { body: sob_comment, user: { login: 'status-open-bounty' } } } },
     { body: { action: 'created', issue: { labels: ['bounty', 'bounty-s'] }, comment: { body: sob_comment, user: { login: 'status-open-bounty' } } } }
-];
+]
 
 describe('Bot behavior', function () {
     describe('#needsFunding()', function () {
         it('should return false because the comment is not from status-open-bounty', function () {
-            assert.isFalse(bot.needsFunding(requests[0]));
-        });
+            assert.isFalse(bot.needsFunding(requests[0]))
+        })
         it('should return false because a user is editing a comment', function () {
-            assert.isFalse(bot.needsFunding(requests[1]));
-        });
+            assert.isFalse(bot.needsFunding(requests[1]))
+        })
         it('should return false because status-open-bounty edited a comment', function () {
-            assert.isFalse(bot.needsFunding(requests[2]));
-        });
+            assert.isFalse(bot.needsFunding(requests[2]))
+        })
         it('should return true, it is all right and we should fund', function () {
-            assert.isTrue(bot.needsFunding(requests[3]));
-        });
-    });
+            assert.isTrue(bot.needsFunding(requests[3]))
+        })
+    })
 
     describe('#getAddress', function () {
         it('should return the address from a status-open-bounty bot comment', function () {
-            assert.equal(bot.getAddress(requests[3]), '0x3645fe42b1a744ad98cc032c22472388806f86f9');
-        });
-    });
+            assert.equal(bot.getAddress(requests[3]), '0x3645fe42b1a744ad98cc032c22472388806f86f9')
+        })
+    })
 
     describe('#getAmount', function () {
         it('should return the amount for the issue given the price per hour and the bounty label for this issue', (done) => {
             bot.getAmount(requests[3])
                 .then(function (amount) {
-                    let label = 'bounty-s';
-                    let tokenPrice = 0.35;
-                    let priceInDollars = config.priceHour * config.bountyLabels[label];
-                    expected_amount = priceInDollars / tokenPrice;
-                    assert.equal(amount, expected_amount);
-                    done();
+                    let label = 'bounty-s'
+                    let tokenPrice = 0.35
+                    let priceInDollars = config.priceHour * config.bountyLabels[label]
+                    expected_amount = priceInDollars / tokenPrice
+                    assert.equal(amount, expected_amount)
+                    done()
                 })
-                .catch(() => { console.log('error'), done() });
-        });
-    });
-});
+                .catch(() => { console.log('error'), done() })
+        })
+    })
+})

--- a/test/test_bot.js
+++ b/test/test_bot.js
@@ -7,10 +7,10 @@ const bot = require('../bot')
 
 
 // status-open-bounty comment from https://github.com/status-im/autobounty/issues/1
-let sob_comment = 'Current balance: 0.000000 ETH\nTokens: SNT: 2500.00 ANT: 25.00\nContract address: 0x3645fe42b1a744ad98cc032c22472388806f86f9\nNetwork: Mainnet\n To claim this bounty sign up at https://openbounty.status.im and make sure to update your Ethereum address in My Payment Details so that the bounty is correctly allocated.\nTo fund it, send ETH or ERC20/ERC223 tokens to the contract address.'
+const sob_comment = 'Current balance: 0.000000 ETH\nTokens: SNT: 2500.00 ANT: 25.00\nContract address: 0x3645fe42b1a744ad98cc032c22472388806f86f9\nNetwork: Mainnet\n To claim this bounty sign up at https://openbounty.status.im and make sure to update your Ethereum address in My Payment Details so that the bounty is correctly allocated.\nTo fund it, send ETH or ERC20/ERC223 tokens to the contract address.'
 
 // Fake requests
-let requests = [
+const requests = [
     { body: { action: 'created', comment: { body: 'Creating my first comment', user: { login: 'randomUser' } } } },
     { body: { action: 'edited', comment: { body: 'Editing my comment', user: { login: 'RandomUser' } } } },
     { body: { action: 'edited', comment: { body: sob_comment, user: { login: 'status-open-bounty' } } } },
@@ -43,9 +43,9 @@ describe('Bot behavior', function () {
         it('should return the amount for the issue given the price per hour and the bounty label for this issue', (done) => {
             bot.getAmount(requests[3])
                 .then(function (amount) {
-                    let label = 'bounty-s'
-                    let tokenPrice = 0.35
-                    let priceInDollars = config.priceHour * config.bountyLabels[label]
+                    const label = 'bounty-s'
+                    const tokenPrice = 0.35
+                    const priceInDollars = config.priceHour * config.bountyLabels[label]
                     expected_amount = priceInDollars / tokenPrice
                     assert.equal(amount, expected_amount)
                     done()


### PR DESCRIPTION
This PR does the following:
- Migrates the coding style to more modern ES6 (using async/await instead of Promise, no semi-colons, use const and let instead of var)
- Adds ESLint so future contributions follow a common style
- Makes the default token be STT instead of SNT
- Updates ethers.js and winston.js packages
- Fixes console logging

For production rollout, be careful to replace the `token` config value, which is now `STT` by default instead of `SNT`